### PR TITLE
Charts: add Helm chart for full-stack deployment

### DIFF
--- a/charts/.helmignore
+++ b/charts/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2  # Helm chart API version
+name: boilerplate-webapp  # Chart name
+description: A helm chart for deploying boilerplate-webapp with frontend, backend, and grpc
+version: 0.1.0  # Helm chart version
+appVersion: "1.0" # Application version

--- a/charts/templates/backend-deployment.yaml
+++ b/charts/templates/backend-deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+  # Optionally, add labels or annotations for observability/tracking
+spec:
+  replicas: {{ .Values.backend.replicaCount }}   # Number of backend pod replicas
+  selector:
+    matchLabels:
+      app: backend      # Must match the pod template label
+  template:
+    metadata:
+      labels:
+        app: backend    # Label used for service discovery
+    spec:
+      containers:
+      - name: backend
+        image: "{{ .Values.backend.image.repository }}:{{ .Values.backend.image.tag }}"
+        imagePullPolicy: IfNotPresent   # Avoids unnecessary pulls if image exists locally
+        ports:
+        - containerPort: {{ .Values.backend.service.port }}   # Exposes internal container port

--- a/charts/templates/backend-service.yaml
+++ b/charts/templates/backend-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+  # Optional: Add annotations for service mesh, monitoring, etc.
+spec:
+  type: {{ .Values.backend.service.type }}  # Service type
+  selector:
+    app: backend  # Must match the Deployment's pod label
+  ports:
+    - port: {{ .Values.backend.service.port }}  # Service port exposed internally
+      targetPort: {{ .Values.backend.service.port }}  # Maps to the container's port

--- a/charts/templates/frontend-deployment.yaml
+++ b/charts/templates/frontend-deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  # Optionally, add labels or annotations for observability/tracking
+spec:
+  replicas: {{ .Values.frontend.replicaCount }}   # Number of backend pod replicas
+  selector:
+    matchLabels:
+      app: frontend      # Must match the pod template label
+  template:
+    metadata:
+      labels:
+        app: frontend    # Label used for service discovery
+    spec:
+      containers:
+      - name: frontend
+        image: "{{ .Values.frontend.image.repository }}:{{ .Values.frontend.image.tag }}"
+        imagePullPolicy: IfNotPresent   # Avoids unnecessary pulls if image exists locally
+        ports:
+        - containerPort: {{ .Values.frontend.service.port }}   # Exposes internal container port

--- a/charts/templates/frontend-ingress.yaml
+++ b/charts/templates/frontend-ingress.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.frontend.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: frontend-ingress
+  annotations:
+    kubernetes.io/ingress.class: "nginx" # Defines the ingress controller to be used
+spec:
+  rules:
+    {{- range .Values.frontend.ingress.hosts }}
+    - host: {{ .host }} # The domain name this rule applies to
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }} # URL path for routing
+            pathType: {{ .pathType }} # Can be 'Prefix' or 'Exact'
+            backend:
+              service:
+                name: frontend  # Target service name (should match metadata.name in frontend service)
+                port:
+                  number: {{ $.Values.frontend.service.port }}  # Port exposed by the frontend service
+          {{- end }}
+    {{- end }}
+  {{- if .Values.frontend.ingress.tls }}
+  tls:
+    {{- range .Values.frontend.ingress.tls }}
+    - secretName: {{ .secretName }} # Kubernetes TLS secret name
+      hosts:
+        {{- range .hosts }}
+        - {{ . }} # Host(s) covered by this TLS secret
+        {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/templates/frontend-service.yaml
+++ b/charts/templates/frontend-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  # Optional: Add annotations for service mesh, monitoring, etc.
+spec:
+  type: {{ .Values.frontend.service.type }} # Service type
+  selector:
+    app: frontend # Must match the Deployment's pod label
+  ports:
+    - port: {{ .Values.frontend.service.port }} # Service port exposed internally
+      targetPort: {{ .Values.frontend.service.port }} # Maps to the container's port

--- a/charts/templates/grpc-deployment.yaml
+++ b/charts/templates/grpc-deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grpc
+  # Optionally, add labels or annotations for observability/tracking
+spec:
+  replicas: {{ .Values.grpc.replicaCount }}   # Number of backend pod replicas
+  selector:
+    matchLabels:
+      app: grpc      # Must match the pod template label
+  template:
+    metadata:
+      labels:
+        app: grpc    # Label used for service discovery
+    spec:
+      containers:
+      - name: grpc
+        image: "{{ .Values.grpc.image.repository }}:{{ .Values.grpc.image.tag }}"
+        imagePullPolicy: IfNotPresent   # Avoids unnecessary pulls if image exists locally
+        ports:
+        - containerPort: {{ .Values.grpc.service.port }}   # Exposes internal container port

--- a/charts/templates/grpc-service.yaml
+++ b/charts/templates/grpc-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: grpc
+  # Optional: Add annotations for service mesh, monitoring, etc.
+spec:
+  type: {{ .Values.grpc.service.type }} # Service type
+  selector:
+    app: grpc # Must match the Deployment's pod label
+  ports:
+    - port: {{ .Values.grpc.service.port }} # Service port exposed internally
+      targetPort: {{ .Values.grpc.service.port }} # Maps to the container's port

--- a/charts/values.development.yaml
+++ b/charts/values.development.yaml
@@ -1,0 +1,28 @@
+frontend:
+  image:
+    tag: dev
+  replicaCount: 1
+  service:
+    type: NodePort
+  ingress:
+    enabled: false
+    hosts:
+      - host: frontend.localhost
+        paths:
+          - path: /
+            pathType: Prefix
+    tls: []  # Normalmente sem TLS em dev/local
+
+backend:
+  image:
+    tag: dev
+  replicaCount: 1
+  service:
+    type: NodePort
+
+grpc:
+  image:
+    tag: dev
+  replicaCount: 1
+  service:
+    type: NodePort

--- a/charts/values.production.yaml
+++ b/charts/values.production.yaml
@@ -1,0 +1,31 @@
+frontend:
+  image:
+    tag: latest
+  replicaCount: 3
+  service:
+    type: ClusterIP
+  ingress:
+    enabled: false
+    hosts:
+      - host: frontend.mycompany.com
+        paths:
+          - path: /
+            pathType: Prefix
+    tls:
+      - secretName: frontend-tls
+        hosts:
+          - frontend.mycompany.com
+
+backend:
+  image:
+    tag: latest
+  replicaCount: 3
+  service:
+    type: ClusterIP
+
+grpc:
+  image:
+    tag: latest
+  replicaCount: 2
+  service:
+    type: ClusterIP

--- a/charts/values.release-0.0.1.yaml
+++ b/charts/values.release-0.0.1.yaml
@@ -1,0 +1,25 @@
+frontend:
+  image:
+    tag: v0.0.1
+  replicaCount: 2
+  ingress:
+    enabled: false
+    hosts:
+      - host: frontend.staging.mycompany.com
+        paths:
+          - path: /
+            pathType: Prefix
+    tls:
+      - secretName: frontend-staging-tls
+        hosts:
+          - frontend.staging.mycompany.com
+
+backend:
+  image:
+    tag: v0.0.1
+  replicaCount: 2
+
+grpc:
+  image:
+    tag: v0.0.1
+  replicaCount: 2

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -1,0 +1,37 @@
+frontend:
+  image:
+    repository: ghcr.io/ghdrope/boilerplate-webapp-frontend # Docker image for frontend
+    tag: latest 
+  replicaCount: 1                                            # Image tag
+  service:
+    type: ClusterIP # Internal service type
+    port: 80        # Frontend listens on port 80
+  ingress:
+    enabled: false  # Ingress disabled by default
+    hosts:
+      - host: frontend.example.com  # Placeholder host for ingress
+        paths:
+          - path: /
+            pathType: Prefix
+    tls:
+      - secretName: frontend-tls  # Optional TLS secret for ingress
+        hosts:
+          - frontend.example.com
+
+backend:
+  image:
+    repository: ghcr.io/ghdrope/boilerplate-webapp-backend  # Docker image for backend
+    tag: latest
+  replicaCount: 1   
+  service:
+    type: ClusterIP
+    port: 8080  # Backend service port
+
+grpc:
+  image:
+    repository: ghcr.io/ghdrope/boilerplate-webapp-grpc # Docker image for gRPC
+    tag: latest
+  replicaCount: 1   
+  service:
+    type: ClusterIP
+    port: 50051 # gRPC port


### PR DESCRIPTION
- Added Helm chart for deploying frontend, backend, and gRPC services
- Supports environment-specific configuration via multiple values.yaml files
- Includes ingress support with customizable class (default: nginx)
- Allows local testing with port-forward and easy uninstallation via Helm