### PR TITLE
Backend: update Kotlin and Java versions to 21, improve Dockerfile setup

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,0 +1,67 @@
+# === Utility-style Makefile for Kotlin/Gradle Backend ===
+
+# === Composite Commands ===
+
+ci_workflow_test: ## Run full CI test suite (format/lint/build/test/coverage)
+	make lint
+	make format-check
+	make build
+	make test
+	make coverage
+
+fix: ## Fix formatting issues with Spotless
+	make format
+
+# === Docker Compose ===
+
+compose-dev: ## Start all services in development environment but as production mode with docker-compose
+	docker-compose -f ../compose/docker-compose-dev.yaml up --build
+
+compose-dev-down: ## Stop all services in development environment
+	docker-compose -f ../compose/docker-compose-dev.yaml down
+
+# === App lifecycle ===
+
+dev: clean ## Run the Spring Boot app in dev mode with 'local' profile
+	SPRING_PROFILES_ACTIVE=local ./gradlew bootRun
+
+preview: clean build ## Build and run the Spring Boot app in production mode
+	@jarfile=$$(ls build/libs/*.jar | head -n 1) && java -jar "$$jarfile" --spring.profiles.active=local
+
+app-dev: clean compose-dev ## Run BeenThere app in development environment but as production mode
+
+app-dev-down: compose-dev-down ## Stop BeenThere app in development environment but as production mode
+
+# === Build lifecycle ===
+
+build: clean ## Clean and build the project
+	./gradlew bootJar
+
+# === Tests and Coverage ===
+
+test: clean ## Run tests
+	./gradlew check
+
+coverage: ## Generate test coverage report (Jacoco)
+	./gradlew jacocoTestReport
+
+# === Quality ===
+
+lint: ## Run static analysis with Detekt
+	./gradlew detekt
+
+format: ## Apply code formatting with Spotless
+	./gradlew spotlessApply
+
+format-check: # Check code formatting without applying changes
+	./gradlew spotlessCheck
+
+# === Cleanup ===
+
+clean: ## Clean build artifacts and caches
+	./gradlew clean
+
+# === Help ===
+
+help: ## Show available commands
+	@grep -E '^[a-zA-Z0-9:_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -1,26 +1,89 @@
 plugins {
-    id("org.springframework.boot") version "3.5.3"
-    id("io.spring.dependency-management") version "1.1.0"
-    kotlin("jvm") version "1.9.0"
-    kotlin("plugin.spring") version "1.9.0"
+    id("org.springframework.boot") version "3.5.4"
+    id("io.spring.dependency-management") version "1.1.4"
+    kotlin("jvm") version "2.0.21"
+    kotlin("plugin.spring") version "2.0.0"
+
+    // Quality tools
+    id("io.gitlab.arturbosch.detekt") version "1.23.8"
+    id("com.diffplug.spotless") version "7.2.1"
+    jacoco  
 }
 
 group = "ghdrope.boilerplate"
-version = "0.0.1-SNAPSHOT"
-java.sourceCompatibility = JavaVersion.VERSION_17
+version = "0.0.2-SNAPSHOT"
+java.sourceCompatibility = JavaVersion.VERSION_21
+
+kotlin {
+    jvmToolchain(21)
+}
 
 repositories {
     mavenCentral()
 }
 
 dependencies {
+    // Spring Boot starters
     implementation("org.springframework.boot:spring-boot-starter-web")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+
+    // Kotlin support
     implementation("org.jetbrains.kotlin:kotlin-reflect")
-    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    
+    // Testing
+    testImplementation("org.springframework.boot:spring-boot-starter-test") {
+        exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
+    }
 }
 
 tasks.withType<Test> {
     ignoreFailures = true
     useJUnitPlatform()
+}
+
+// Jacoco config
+jacoco {
+    toolVersion = "0.8.13"
+}
+
+tasks.jacocoTestReport {
+    dependsOn(tasks.test)
+    reports {
+        html.required.set(true)
+        xml.required.set(false)
+        csv.required.set(false)
+    }
+}
+
+tasks.jacocoTestCoverageVerification {
+    dependsOn(tasks.test)
+    violationRules {
+        rule {
+            limit {
+                minimum = "0.75".toBigDecimal() // requires >= 75% coverage
+            }
+        }
+    }
+    sourceSets(sourceSets.main.get())
+    executionData.setFrom(fileTree(buildDir).include("/jacoco/*.exec"))
+}
+
+tasks.check {
+    dependsOn(tasks.jacocoTestCoverageVerification)
+}
+
+// Detekt config
+detekt {
+    config = files("detekt.yml")
+    buildUponDefaultConfig = true
+    allRules = false
+}
+
+// Spotless formatting
+spotless {
+    kotlin {
+        target("src/**/*.kt")
+        ktlint()
+    }
 }

--- a/backend/detekt.yml
+++ b/backend/detekt.yml
@@ -1,0 +1,9 @@
+style:
+  MagicNumber:
+    active: false
+  WildcardImport:
+    active: false
+  
+comments:
+  UndocumentedPublicClass:
+    active: false

--- a/backend/gradle.properties
+++ b/backend/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false

--- a/backend/settings.gradle.kts
+++ b/backend/settings.gradle.kts
@@ -1,1 +1,9 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+        google()
+    }
+}
+
 rootProject.name = "boilerplate"

--- a/backend/src/main/kotlin/ghdrope/boilerplate/backend/BackendApplication.kt
+++ b/backend/src/main/kotlin/ghdrope/boilerplate/backend/BackendApplication.kt
@@ -17,8 +17,8 @@ class BackendApplication
  *
  * Runs the Spring Boot application.
  *
- * @param args command-line arguments
+ * @param args command-line arguments passed at startup.
  */
-fun main(args: Array<String>) {
+fun main(vararg args: String) {
     runApplication<BackendApplication>(*args)
 }

--- a/backend/src/main/kotlin/ghdrope/boilerplate/backend/HelloController.kt
+++ b/backend/src/main/kotlin/ghdrope/boilerplate/backend/HelloController.kt
@@ -1,21 +1,35 @@
 package ghdrope.boilerplate.backend
 
+import org.slf4j.LoggerFactory
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
 
 /**
- * REST controller that exposes backend endpoints.
+ * REST controller exposing a basic health check endpoint.
+ *
+ * Useful for verifying that the backend is up and responsive.
  */
 @RestController
 class HelloController {
-    
+    private val logger = LoggerFactory.getLogger(HelloController::class.java)
+
+    companion object {
+        /**
+         * Static greeting message used in the `/hello` response.
+         */
+        private const val GREETING = "Hello from backend!"
+    }
+
     /**
-     * HTTP GET endpoint at `/hello`.
+     * GET `/hello`.
      *
-     * Returns a simple greeting string.
+     * Returns a simple greeting message for health check or testing purposes.
      *
-     * @return greeting message
+     * @return A static greeting string
      */
     @GetMapping("/hello")
-    fun hello() = "Hello from backend!"
+    fun hello(): String {
+        logger.info("Health check endpoint `/hello` called.")
+        return GREETING
+    }
 }

--- a/docker/backend.dockerfile
+++ b/docker/backend.dockerfile
@@ -1,34 +1,43 @@
 #
 # ----- Stage 1: Build -----
 #
-FROM gradle:8.3-jdk17 AS builder
+FROM eclipse-temurin:21-jdk-alpine AS builder
 
-WORKDIR /backend
+WORKDIR /app
 
-# Copy build files to leverage Docker cache for dependencies
-COPY backend/build.gradle.kts backend/settings.gradle.kts ./
+# Copy wrapper and build scripts first for better caching
+COPY backend/gradlew backend/gradlew.bat ./
 COPY backend/gradle ./gradle
+COPY backend/build.gradle.kts backend/settings.gradle.kts ./
 
-# Download dependencies (cache step)
-RUN gradle --no-daemon build -x test || true
+# Ensure wrapper is executable
+RUN chmod +x gradlew
 
-# Copy the rest of the source code
+# Pre-download dependencies to leverage Docker cache
+RUN ./gradlew --no-daemon dependencies
+
+# Copy the application source
 COPY backend/src ./src
 
-# Build the Spring Boot jar (skip tests for faster builds)
-RUN gradle --no-daemon clean bootJar -x test
+# Build only the bootable JAR (skip tests, linting, formatting checks)
+RUN ./gradlew --no-daemon clean bootJar -x test -x detekt -x spotlessCheck
+
+
 
 #
 # ----- Stage 2: Runtime -----
 #
-FROM eclipse-temurin:17-jre
+FROM eclipse-temurin:21-jdk-alpine
 
-WORKDIR /backend
+# Install curl
+RUN apk add --no-cache curl
 
-# Copy the jar built from the previous stage
-COPY --from=builder /backend/build/libs/*.jar app.jar
+WORKDIR /app
 
-# Expose default Spring Boot port
+# Copy only the final built JAR
+COPY --from=builder /app/build/libs/*.jar app.jar
+
+# Spring Boot default port
 EXPOSE 8080
 
 # Entrypoint for distroless


### PR DESCRIPTION
- Upgrade Kotlin to latest version compatible with Java 21
- Update JDK from 17 to 21 in build.gradle.kts
- Update detekt and spotless plugins to compatible versions
- Refactor Dockerfile to use eclipse-temurin:21-jdk-alpine base image for runtime
- Add curl installation to runtime image for health check support
- Fix Dockerfile CMD to run the JAR with java -jar