### PR TITLE
Compose healthchecks & .dockerignore

### DIFF
--- a/compose/docker-compose-dev.yaml
+++ b/compose/docker-compose-dev.yaml
@@ -1,0 +1,46 @@
+services:
+  backend:
+    build:
+      context: ..
+      dockerfile: docker/backend.dockerfile
+    container_name: boilerplate-webapp-backend
+    ports:
+      - 8080:8080
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/hello"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped
+
+  grpc:
+    depends_on:
+      backend:
+        condition: service_healthy
+    build:
+      context: ..
+      dockerfile: docker/grpc.dockerfile
+    container_name: boilerplate-webapp-grpc
+    ports:
+      - 50051:50051
+    environment:
+      - ENV=dev
+    healthcheck:
+      test: ["CMD", "grpc_health_probe", "-addr=localhost:50051"]
+      interval: 5s
+      retries: 5
+      start_period: 5s
+    restart: unless-stopped
+
+  frontend:
+    depends_on:
+      grpc:
+        condition: service_healthy
+    build:
+      context: ..
+      dockerfile: docker/frontend.dockerfile
+    container_name: boilerplate-webapp-frontend
+    ports:
+      - 3000:80
+    restart: unless-stopped

--- a/compose/docker-compose.yaml
+++ b/compose/docker-compose.yaml
@@ -3,24 +3,38 @@ services:
     build:
       context: ..
       dockerfile: docker/backend.dockerfile
-    ports:
-      - 8080:8080
+    container_name: boilerplate-webapp-backend
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/hello"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+      start_period: 5s
     restart: unless-stopped
-  frontend:
-    depends_on:
-      - backend
-    build:
-      context: ..
-      dockerfile: docker/frontend.dockerfile
-    ports:
-      - 3000:80
-    restart: unless-stopped
+
   grpc:
     depends_on:
-      - backend
+      backend:
+        condition: service_healthy
     build:
       context: ..
       dockerfile: docker/grpc.dockerfile
+    container_name: boilerplate-webapp-grpc
+    healthcheck:
+      test: ["CMD", "grpc_health_probe", "-addr=localhost:50051"]
+      interval: 5s
+      retries: 5
+      start_period: 5s
+    restart: unless-stopped
+
+  frontend:
+    depends_on:
+      grpc:
+        condition: service_healthy
+    build:
+      context: ..
+      dockerfile: docker/frontend.dockerfile
+    container_name: boilerplate-webapp-frontend
     ports:
-      - 50051:50051
+      - 3000:80
     restart: unless-stopped

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,0 +1,72 @@
+# -------------------------
+# Backend
+# -------------------------
+
+.gradle/
+.git/
+**/*.iml
+*.log
+build/
+
+# -------------------------
+# Frontend (Node.js-based projects)
+# -------------------------
+
+# Node modules
+node_modules/
+
+# Build output directories
+dist/
+build/
+out/
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Dependency directories for Plug'n'Play (if used)
+.pnp/
+.pnp.js
+
+# Environment files (optional, for security)
+.env
+.env.local
+.env.*.local
+
+# IDE/editor configs
+.vscode/
+.idea/
+*.iml
+
+# OS generated files
+.DS_Store
+Thumbs.db
+
+# -------------------------
+# gRPC / Protobuf generated code and build outputs
+# -------------------------
+
+# Build outputs and caches
+.build/
+target/
+out/
+
+# Protobuf generated files (auto-generated)
+**/*.pb.go
+**/*.pb.java
+**/*.pb.swift
+**/*.pb.py
+
+# Logs
+*.log
+
+# IDE/editor configs
+.vscode/
+.idea/
+*.iml
+
+# OS generated files
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
Compose: add docker-compose-dev and update docker-compose with healthchecks and container configs
  - Added a new docker-compose-dev.yaml for development environment with proper healthchecks, port mappings, and environment variables
  - Updated docker-compose.yaml to include container names, healthchecks for backend and grpc services
  - Reordered services to ensure proper dependency conditions using health status
  - Added environment variable for grpc service in dev compose

Docker: add .dockerignore for backend, frontend, and grpc