### PR TITLE
Security: update ZAP ignore rules to exclude non-actionable alerts

### DIFF
--- a/.github/workflows/dast_frontend.yml
+++ b/.github/workflows/dast_frontend.yml
@@ -10,6 +10,7 @@ on:
     paths:
       - 'frontend/**'
       - 'docker/frontend.dockerfile'
+      - '.zap/rules.tsv'
   push:
     branches:
       - development
@@ -18,6 +19,7 @@ on:
     paths:
       - 'frontend/**'
       - 'docker/frontend.dockerfile'
+      - '.zap/rules.tsv'
 
 jobs:
   dast-owasp-zap:

--- a/.zap/rules.tsv
+++ b/.zap/rules.tsv
@@ -7,3 +7,10 @@
 10202	IGNORE	Information Disclosure - Sensitive Information in URL
 90033	IGNORE	Web Browser XSS Protection Not Enabled
 90035	IGNORE	CSP: Wildcard Directive
+
+90004	IGNORE	Insufficient Site Isolation Against Spectre Vulnerability
+10109	IGNORE	Modern Web Application
+10036	IGNORE	Server Leaks Version Information via "Server" HTTP Response Header Field
+10027	IGNORE	Information Disclosure - Suspicious Comments
+90005	IGNORE	Sec-Fetch Headers Missing
+10049	IGNORE	Storable and Cacheable Content


### PR DESCRIPTION
- Added IDs 90004, 10109, 10036, 10027, 90005, 10049 to ignore list
- Kept previous ignore rules for common non-critical alerts